### PR TITLE
Add homepage to package.json for links in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Universal HTTP library for Node.js, Deno & Serverless (Cloudflare, Vercel, Netlify)",
   "types": "index.d.ts",
   "main": "index.js",
+  "repository": "github:kreteshq/retes",
+  "homepage": "https://github.com/kreteshq/retes",
+  "bugs": {
+    "url": "https://github.com/kreteshq/retes/issues"
+  },
   "scripts": {
     "prepublishOnly": "pnpm build",
     "watch": "tsc -w",


### PR DESCRIPTION
I want to merge this because it adds `homepage` property so that the package has a link to the GitHub repo on npm website: 

![CleanShot 2022-06-07 at 14 52 03@2x](https://user-images.githubusercontent.com/4144459/172384071-9254290c-973b-4588-a808-e4e46ae2c96d.png)
![CleanShot 2022-06-07 at 14 52 32@2x](https://user-images.githubusercontent.com/4144459/172384092-47bd7568-f1cb-46df-ba1f-85acd92578ad.png)

