### PR TITLE
Fix handler type when passed to pipeline

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export interface Request<I = Params> {
 export type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
 
 export type Handler<I = Params, O extends BodyInit = BodyInit> = (request: Request<I>) => MaybePromise<Response<O>>;
-export type Pipeline = [...Middleware[], Handler];
+export type Pipeline = [...Middleware[], Handler<any, any>];
 export type ReversedPipeline = [Handler, ...Middleware[]];
 
 export interface Meta {


### PR DESCRIPTION
I want to merge this, because it fixes an issue when handler that used generic parameters was passed into a pipeline (for example `toNextHandler`).

Without this change, here's an error [from a handler](https://github.com/saleor/saleor-checkout/blob/SALEOR-7524-update-jsw-validation/apps/checkout-app/pages/api/webhooks/saleor/transaction-action-request.ts#L29) that used generic parameter to define type of `params`:

<img width="1227" alt="CleanShot 2022-07-18 at 13 42 44@2x" src="https://user-images.githubusercontent.com/4144459/179504586-394cb8fb-0efa-45a5-a280-3e105cc302fa.png">